### PR TITLE
Composed instance method updated to use wrappers, rebased on upstream master

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "presets": ["react", "es2015", "stage-0"],
-  "plugins": ["transform-runtime"]
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,0 @@
-{
-  "extends": "airbnb",
-  "parser": "babel-eslint"
-}

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,10 +7,8 @@
 # (this is required in order to prevent newline related issues like,
 # for example, after the build script is run)
 .*      text eol=lf
-*.css   text eol=lf
-*.html  text eol=lf
 *.js    text eol=lf
 *.json  text eol=lf
 *.md    text eol=lf
 *.txt   text eol=lf
-*.xml   text eol=lf
+*.yml   text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Include your project-specific ignores in this file
 # Read about how to use .gitignore: https://help.github.com/articles/ignoring-files
 
+coverage
 lib
 node_modules
 npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,4 @@
 .idea
-.babelrc
-.editorconfig
-.eslintrc
-.gitattributes
-.gitignore
-.npmignore
 .travis.yml
+coverage
 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - '4.2'
-  - '5.1'
+  - '5'
+  - '4'
+script:
+  - npm run lint
+  - npm run test:cover
+after_success:
+  - npm run coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+## Isomorphic Style Loader Change Log
+
+All notable changes to this project will be documented in this file.
+
+### [Unreleased][unreleased]
+
+- Add `CHANGELOG.md` file with the past and future (planned) changes to the project
+
+### [v1.0.0]
+> 2016-04-15
+
+- Improve comparability with Hot Module Replacement (HMR) [PR#33](https://github.com/kriasoft/isomorphic-style-loader/pull/33)
+- Add support of ES2015+ decorator syntax, e.g. `@withStyles(s) class MyComponent extends Component { .. }`
+  [PR#21](https://github.com/kriasoft/isomorphic-style-loader/pull/21) (BREAKING CHANGE)
+
+### [v0.0.12]
+> 2016-03-04
+
+- Fix style not getting removed for multiple instance [PR#23](https://github.com/kriasoft/isomorphic-style-loader/pull/23)
+
+[unreleased]: https://github.com/kriasoft/isomorphic-style-loader/compare/v1.0.0...HEAD
+[v1.0.0]: https://github.com/kriasoft/isomorphic-style-loader/compare/v0.0.12...v1.0.0
+[v0.0.12]: https://github.com/kriasoft/isomorphic-style-loader/compare/v0.0.11...v0.0.12

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const server = express();
 const port = process.env.PORT || 3000;
 
 // Server-side rendering of the React app
-server.get('*', (req, res, next) => 
+server.get('*', (req, res, next) =>
   const css = []; // CSS for all rendered React components
   const context = { insertCss: (styles) => css.push(styles._getCss()) };
   router.dispatch({ ...req, context }).then((component, state) => {
@@ -114,11 +114,11 @@ It should generate an HTML output similar to this one:
 ```html
 <html>
   <head>
-    <title>My Application</title>                                    
+    <title>My Application</title>
     <script async src="/client.js"></script>
     <style type="text/css">
       .MyComponent_root_Hi8 { padding: 10px; }
-      .MyComponent_title_e9Q { color: red; } 
+      .MyComponent_title_e9Q { color: red; }
     </style>
   </head>
   <body>
@@ -137,6 +137,9 @@ section of HTML document. Critical CSS is what actually used on the
 requested web page, effectively dealing with [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)
 issue and improving client-side performance. CSS of the unmounted components
 will be removed from the DOM.
+
+##### Hot reload
+You can activate hot module reload for style by setting the `debug` option to true in your webpack configuration. If you are using webpack 2, you need to supply it though the `LoaderOptionsPlugin` because the [`debug` option has been removed](https://gist.github.com/sokra/27b24881210b56bbaff7#loader-options--minimize)
 
 ### Backers
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![NPM version](http://img.shields.io/npm/v/isomorphic-style-loader.svg?style=flat-square)](https://www.npmjs.com/package/isomorphic-style-loader)
 [![NPM downloads](http://img.shields.io/npm/dm/isomorphic-style-loader.svg?style=flat-square)](https://www.npmjs.com/package/isomorphic-style-loader)
 [![Build Status](http://img.shields.io/travis/kriasoft/isomorphic-style-loader/master.svg?style=flat-square)](https://travis-ci.org/kriasoft/isomorphic-style-loader)
+[![Coverage Status](https://img.shields.io/coveralls/kriasoft/isomorphic-style-loader.svg?style=flat-square)](https://coveralls.io/github/kriasoft/isomorphic-style-loader)
 [![Dependency Status](http://img.shields.io/david/kriasoft/isomorphic-style-loader.svg?style=flat-square)](https://david-dm.org/kriasoft/isomorphic-style-loader)
 [![Chat](http://img.shields.io/badge/chat_room-%23react--starter--kit-blue.svg?style=flat-square)](https://gitter.im/kriasoft/react-starter-kit)
 
@@ -138,8 +139,11 @@ requested web page, effectively dealing with [FOUC](https://en.wikipedia.org/wik
 issue and improving client-side performance. CSS of the unmounted components
 will be removed from the DOM.
 
-##### Hot reload
-You can activate hot module reload for style by setting the `debug` option to true in your webpack configuration. If you are using webpack 2, you need to supply it though the `LoaderOptionsPlugin` because the [`debug` option has been removed](https://gist.github.com/sokra/27b24881210b56bbaff7#loader-options--minimize)
+##### Hot Reload
+
+You can activate hot module reload for style by setting the `debug` option to true in your webpack
+configuration. If you are using webpack 2, you need to supply it though the `LoaderOptionsPlugin`
+because the [`debug` option has been removed](https://gist.github.com/sokra/27b24881210b56bbaff7#loader-options--minimize).
 
 ### Backers
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ function MyComponent(props, context) {
   );
 }
 
-export default withStyles(MyComponent, s);        // <--
+export default withStyles(s)(MyComponent);        // <--
 ```
 
 **P.S.**: It works great with [CSS Modules](https://github.com/css-modules/css-modules)!

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
 > `styles` object - `._insertCss()` (injects CSS into the DOM) and `._getCss()`
 > (returns CSS string).
 
+See [getting started](#getting-started) &nbsp;|&nbsp; [changelog](CHANGELOG.md) &nbsp;|&nbsp;
+Join [#react-starter-kit](https://gitter.im/kriasoft/react-starter-kit) chat room on Gitter to stay
+up to date
+
 ### How to Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ requested web page, effectively dealing with [FOUC](https://en.wikipedia.org/wik
 issue and improving client-side performance. CSS of the unmounted components
 will be removed from the DOM.
 
+### Backers
+
+♥ Isomorphic Style Loader? Help us keep it alive by [donating funds](https://www.patreon.com/tarkus) to cover project expenses!
+
+<a href="https://github.com/koistya" target="_blank">
+  <img src="https://github.com/koistya.png?size=64">
+</a>
+<a href="https://www.patreon.com/bePatron?patAmt=25&amp;u=2475816" target="_blank">
+  <img src="https://opencollective.com/static/images/become_backer.svg">
+</a>
+
 ### Related Projects
 
  * [React Starter Kit](https://github.com/kriasoft/react-starter-kit) — Isomorphic web app boilerplate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horyd-isomorphic-style-loader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Isomorphic CSS style loader for Webpack",
   "repository": "horyd/isomorphic-style-loader",
   "author": "Kriasoft <support@kriasoft.com> (http://www.kriasoft.com)",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jsdom": "^8.3.1",
     "mocha": "^2.4.5",
     "react": "^15.0.1",
+    "react-addons-test-utils": "^0.14.7",
     "rimraf": "^2.5.2",
     "sinon": "^2.0.0-pre"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horyd-isomorphic-style-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Isomorphic CSS style loader for Webpack",
   "repository": "horyd/isomorphic-style-loader",
   "author": "Kriasoft <support@kriasoft.com> (http://www.kriasoft.com)",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "isomorphic-style-loader",
+  "name": "horyd-isomorphic-style-loader",
   "version": "1.0.0",
   "description": "Isomorphic CSS style loader for Webpack",
-  "repository": "kriasoft/isomorphic-style-loader",
+  "repository": "horyd/isomorphic-style-loader",
   "author": "Kriasoft <support@kriasoft.com> (http://www.kriasoft.com)",
   "contributors": [
     "Konstantin Tarkus <hello@tarkus.me>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-style-loader",
-  "version": "0.0.12",
+  "version": "1.0.0",
   "description": "Isomorphic CSS style loader for Webpack",
   "repository": "kriasoft/isomorphic-style-loader",
   "author": "Kriasoft <support@kriasoft.com> (http://www.kriasoft.com)",
@@ -11,12 +11,14 @@
   "keywords": [
     "webpack",
     "webpack-loader",
+    "webpack loader",
     "loader",
     "css",
     "scss",
     "style",
     "styles",
     "style-loader",
+    "style loader",
     "react",
     "reactjs",
     "isomorphic",
@@ -24,32 +26,52 @@
   ],
   "license": "MIT",
   "main": "lib/index.js",
+  "babel": {
+    "presets": [
+      "react",
+      "es2015",
+      "stage-0"
+    ],
+    "plugins": [
+      "transform-runtime"
+    ]
+  },
+  "eslintConfig": {
+    "parser": "babel-eslint",
+    "extends": "airbnb"
+  },
   "dependencies": {
-    "babel-runtime": "^6.3.19",
-    "loader-utils": "^0.2.0"
+    "babel-runtime": "^6.6.1",
+    "loader-utils": "^0.2.14"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
-    "babel-cli": "^6.5.1",
-    "babel-core": "^6.5.2",
-    "babel-eslint": "^5.0.0",
-    "babel-plugin-transform-runtime": "^6.5.2",
-    "babel-preset-es2015": "^6.5.0",
+    "babel-cli": "^6.7.5",
+    "babel-core": "^6.7.6",
+    "babel-eslint": "^6.0.2",
+    "babel-plugin-transform-runtime": "^6.7.5",
+    "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.7.2",
     "chai": "^3.5.0",
-    "eslint": "^1.10.3",
-    "eslint-config-airbnb": "5.0.1",
-    "eslint-plugin-react": "^3.16.1",
-    "jsdom": "^8.0.3",
+    "coveralls": "^2.11.9",
+    "eslint": "^2.7.0",
+    "eslint-config-airbnb": "7.0.0",
+    "eslint-plugin-jsx-a11y": "^0.6.2",
+    "eslint-plugin-react": "^4.3.0",
+    "istanbul": "^1.0.0-alpha.2",
+    "jsdom": "^8.3.1",
     "mocha": "^2.4.5",
-    "react": "^0.14.7",
+    "react": "^15.0.1",
     "rimraf": "^2.5.2",
-    "sinon": "^1.17.3"
+    "sinon": "^2.0.0-pre"
   },
   "scripts": {
     "lint": "eslint src test",
-    "test": "eslint src test && mocha test --compilers js:babel-core/register",
+    "test": "mocha test --compilers js:babel-register",
+    "test:watch": "mocha --compilers js:babel-register --reporter min --watch",
+    "test:cover": "babel-node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha",
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
     "build": "rimraf lib && babel src --out-dir lib",
     "prepublish": "rimraf lib && babel src --out-dir lib"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -27,22 +27,23 @@ module.exports.pitch = function pitch(remainingRequest) {
 
     module.exports = content.locals || {};
     module.exports._getCss = function() { return content.toString(); };
-    module.exports._insertCss = insertCss.bind(null, content);
+    module.exports._insertCss = function(options) { return insertCss(content, options) };
   `;
 
   output += this.debug ? `
-    var removeCss = function() {};
-
     // Hot Module Replacement
     // https://webpack.github.io/docs/hot-module-replacement
     // Only activated in browser context
     if (module.hot && typeof window !== 'undefined' && window.document) {
+      var removeCss = function() {};
       module.hot.accept(${stringifyRequest(this, `!!${remainingRequest}`)}, function() {
-        var newContent = require(${stringifyRequest(this, `!!${remainingRequest}`)});
-        if (typeof newContent === 'string') {
-          newContent = [[module.id, content, '']];
+        content = require(${stringifyRequest(this, `!!${remainingRequest}`)});
+
+        if (typeof content === 'string') {
+          content = [[module.id, content, '']];
         }
-        removeCss = insertCss(newContent, { replace: true });
+
+        removeCss = insertCss(content, { replace: true });
       });
       module.hot.dispose(function() { removeCss(); });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * Isomorphic CSS style loader for Webpack
  *
- * Copyright © 2015 Kriasoft, LLC. All rights reserved.
+ * Copyright © 2015-2016 Kriasoft, LLC. All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE.txt file in the root directory of this source tree.

--- a/src/insertCss.js
+++ b/src/insertCss.js
@@ -1,7 +1,7 @@
 /**
  * Isomorphic CSS style loader for Webpack
  *
- * Copyright © 2015 Kriasoft, LLC. All rights reserved.
+ * Copyright © 2015-2016 Kriasoft, LLC. All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE.txt file in the root directory of this source tree.

--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -37,7 +37,7 @@ function withStyles(...styles) {
         rest[0];
       let wrappedInstance = this.refs.wrappedInstance;
       let i = levelsOfWrapping;
-      for (i; i--; i > 1) {
+      for (i; i > 1; i--) {
         wrappedInstance = wrappedInstance.getWrappedInstance(i - 1);
       }
       return wrappedInstance;

--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -9,18 +9,18 @@
 
 import React, { Component, PropTypes } from 'react';
 
-function getDisplayName(ComposedComponent) {
-  return ComposedComponent.displayName || ComposedComponent.name || 'Component';
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
 }
 
 function withStyles(...styles) {
-  return (ComposedComponent) => class WithStyles extends Component {
+  return (WrappedComponent) => class WithStyles extends Component {
     static contextTypes = {
       insertCss: PropTypes.func.isRequired,
     };
 
-    static displayName = `WithStyles(${getDisplayName(ComposedComponent)})`;
-    static ComposedComponent = ComposedComponent;
+    static displayName = `WithStyles(${getDisplayName(WrappedComponent)})`;
+    static WrappedComponent = WrappedComponent;
 
     componentWillMount() {
       this.removeCss = this.context.insertCss.apply(undefined, styles);
@@ -30,12 +30,12 @@ function withStyles(...styles) {
       setTimeout(this.removeCss, 0);
     }
 
-    getComposedInstance() {
-      return this.refs.composedInstance;
+    getWrappedInstance() {
+      return this.refs.wrappedInstance;
     }
 
     render() {
-      return <ComposedComponent ref="composedInstance" {...this.props} />;
+      return <WrappedComponent ref="wrappedInstance" {...this.props} />;
     }
   };
 }

--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -30,8 +30,12 @@ function withStyles(...styles) {
       setTimeout(this.removeCss, 0);
     }
 
+    getComposedInstance() {
+      return this.refs.composedInstance;
+    }
+
     render() {
-      return <ComposedComponent {...this.props} />;
+      return <ComposedComponent ref="composedInstance" {...this.props} />;
     }
   };
 }

--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -30,8 +30,17 @@ function withStyles(...styles) {
       setTimeout(this.removeCss, 0);
     }
 
-    getWrappedInstance() {
-      return this.refs.wrappedInstance;
+    getWrappedInstance(...rest) {
+      const levelsOfWrapping = rest.length <= 0
+        || rest[0] === undefined ?
+        1 :
+        rest[0];
+      let wrappedInstance = this.refs.wrappedInstance;
+      let i = levelsOfWrapping;
+      for (i; i--; i > 1) {
+        wrappedInstance = wrappedInstance.getWrappedInstance(i - 1);
+      }
+      return wrappedInstance;
     }
 
     render() {

--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -1,7 +1,7 @@
 /**
  * Isomorphic CSS style loader for Webpack
  *
- * Copyright © 2015 Kriasoft, LLC. All rights reserved.
+ * Copyright © 2015-2016 Kriasoft, LLC. All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE.txt file in the root directory of this source tree.

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,7 +1,12 @@
 {
   "rules": {
+    "max-len": [2, 120, 2, {
+      "ignoreUrls": true,
+      "ignoreComments": false
+    }],
     "no-unused-expressions": 0,
     "react/no-multi-comp": 0,
-    "react/prefer-es6-class": 0
+    "react/prefer-es6-class": 0,
+    "react/prefer-stateless-function": 0
   }
 }

--- a/test/insertCssSpec.js
+++ b/test/insertCssSpec.js
@@ -7,13 +7,10 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import jsdom from 'jsdom';
+
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import insertCss from '../src/insertCss';
-
-global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-global.window = document.parentWindow;
 
 describe('insertCss(styles, options)', () => {
   it('Should insert and remove <style> element', () => {

--- a/test/insertCssSpec.js
+++ b/test/insertCssSpec.js
@@ -1,3 +1,12 @@
+/**
+ * Isomorphic CSS style loader for Webpack
+ *
+ * Copyright © 2015-2016 Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
 import jsdom from 'jsdom';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,5 @@
+import { jsdom } from 'jsdom';
+
+global.document = jsdom('<!doctype html><html><body></body></html>');
+global.window = document.defaultView;
+global.navigator = global.window.navigator;

--- a/test/withStylesSpec.js
+++ b/test/withStylesSpec.js
@@ -11,11 +11,23 @@
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import React, { createClass, Component } from 'react';
+import React, { createClass, Component, PropTypes } from 'react';
+import TestUtils from 'react-addons-test-utils';
 import withStyles from '../src/withStyles';
 
+describe('withStyles(...styles)(ComposedComponent)', () => {
+  class Provider extends Component {
+    static childContextTypes = {
+      insertCss: PropTypes.func.isRequired,
+    };
+    getChildContext() {
+      return { insertCss() {} };
+    }
+    render() {
+      return <div {...this.props} />;
+    }
+  }
 
-describe('withStyles(ComposedComponent, ...styles)', () => {
   class Passthrough extends Component {
     render() {
       return <div {...this.props} />;
@@ -56,7 +68,35 @@ describe('withStyles(ComposedComponent, ...styles)', () => {
       }
     }
 
-    const decorated = withStyles('')(Container);
-    expect(decorated.ComposedComponent).to.equal(Container);
+    const Decorated = withStyles('')(Container);
+    expect(Decorated.ComposedComponent).to.equal(Container);
+  });
+
+  it('Should return the instance of the composed component for use in calling child methods', () => {
+    const someData = { some: 'data' };
+
+    class Container extends Component {
+      someInstanceMethod() {
+        return someData;
+      }
+
+      render() {
+        return <Passthrough />;
+      }
+    }
+
+    const Decorated = withStyles('')(Container);
+
+    const tree = TestUtils.renderIntoDocument(
+      <Provider>
+        <Decorated />
+      </Provider>
+    );
+
+    const decorated = TestUtils.findRenderedComponentWithType(tree, Decorated);
+
+    expect(() => decorated.someInstanceMethod()).to.throw(Error);
+    expect(decorated.getComposedInstance().someInstanceMethod()).to.equal(someData);
+    expect(decorated.refs.composedInstance.someInstanceMethod()).to.equal(someData);
   });
 });

--- a/test/withStylesSpec.js
+++ b/test/withStylesSpec.js
@@ -15,7 +15,7 @@ import React, { createClass, Component, PropTypes } from 'react';
 import TestUtils from 'react-addons-test-utils';
 import withStyles from '../src/withStyles';
 
-describe('withStyles(...styles)(ComposedComponent)', () => {
+describe('withStyles(...styles)(WrappedComponent)', () => {
   class Provider extends Component {
     static childContextTypes = {
       insertCss: PropTypes.func.isRequired,
@@ -61,7 +61,7 @@ describe('withStyles(...styles)(ComposedComponent)', () => {
     ).displayName).to.equal('WithStyles(Component)');
   });
 
-  it('Should expose the component with styles as ComposedComponent', () => {
+  it('Should expose the component with styles as WrappedComponent', () => {
     class Container extends Component {
       render() {
         return <Passthrough />;
@@ -69,10 +69,10 @@ describe('withStyles(...styles)(ComposedComponent)', () => {
     }
 
     const Decorated = withStyles('')(Container);
-    expect(Decorated.ComposedComponent).to.equal(Container);
+    expect(Decorated.WrappedComponent).to.equal(Container);
   });
 
-  it('Should return the instance of the composed component for use in calling child methods', () => {
+  it('Should return the instance of the wrapped component for use in calling child methods', () => {
     const someData = { some: 'data' };
 
     class Container extends Component {
@@ -96,7 +96,7 @@ describe('withStyles(...styles)(ComposedComponent)', () => {
     const decorated = TestUtils.findRenderedComponentWithType(tree, Decorated);
 
     expect(() => decorated.someInstanceMethod()).to.throw(Error);
-    expect(decorated.getComposedInstance().someInstanceMethod()).to.equal(someData);
-    expect(decorated.refs.composedInstance.someInstanceMethod()).to.equal(someData);
+    expect(decorated.getWrappedInstance().someInstanceMethod()).to.equal(someData);
+    expect(decorated.refs.wrappedInstance.someInstanceMethod()).to.equal(someData);
   });
 });

--- a/test/withStylesSpec.js
+++ b/test/withStylesSpec.js
@@ -1,7 +1,19 @@
+/**
+ * Isomorphic CSS style loader for Webpack
+ *
+ * Copyright © 2015-2016 Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+/* eslint-disable react/prefer-stateless-function */
+
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import React, { createClass, Component } from 'react';
 import withStyles from '../src/withStyles';
+
 
 describe('withStyles(ComposedComponent, ...styles)', () => {
   class Passthrough extends Component {


### PR DESCRIPTION
Hi @frenzzy. I found your PR on kriasoft/isomorphic-style-loader and wanted to submit an update to it. Only the one, very simple commit, and rebased on top of master to get this in asap with a bit of luck ;) Figured best to just submit a PR to your branch, to keep the conversation going on the main repo and all.

I changed the naming of the methods and so on to be in-line with what other HOCs, such as `connect` by react-redux and `injectIntl` by react-intl, use. Let me know what you think.
